### PR TITLE
Support encoded email addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,22 @@ function cleanup () {
 }
 
 /**
+ * Decodes a username to an email address
+ * 
+ * @param {string} username
+ * @returns {string}
+ * @access private
+ */
+function decodeUsernameToEmail(username) {
+    var pos = username.lastIndexOf('..');
+    if (pos === -1) {
+        return username;
+    }
+  
+    return username.substr(0, pos) + '@' + username.substr(pos+2);
+}
+
+/**
  * Returns cached record for a given user
  * This is private method running in context of Auth object
  *
@@ -121,7 +137,7 @@ function getCache (username, password) {
     var shasum = crypto.createHash('sha1');
 
     shasum.update(JSON.stringify({
-        username: username,
+        username: decodeUsernameToEmail(username),
         password: password
     }));
 

--- a/index.js
+++ b/index.js
@@ -107,7 +107,13 @@ function cleanup () {
 }
 
 /**
- * Decodes a username to an email address
+ * Decodes a username to an email address.
+ * 
+ * Since the local portion of email addresses
+ * can't end with a dot or contain two consecutive
+ * dots, we can replace the `@` with `..`. This
+ * function converts from the above encoding to
+ * a proper email address.
  * 
  * @param {string} username
  * @returns {string}
@@ -119,7 +125,7 @@ function decodeUsernameToEmail(username) {
         return username;
     }
   
-    return username.substr(0, pos) + '@' + username.substr(pos+2);
+    return username.substr(0, pos) + '@' + username.substr(pos + 2);
 }
 
 /**


### PR DESCRIPTION
Given [issue #2](https://github.com/Mikhus/sinopia-bitbucket/issues/2), I figured out it was indeed a problem bitbucket requiring email addresses and npm disallowing email addresses as usernames. I don't think there's much if anything to be done to fix this issue, so I thought about work arounds. I put this together, which worked for me. You can look at the commit messages and docblock for an explanation of what's going on. Let me know what you think.
